### PR TITLE
宿題#1:UWPでエラーになるのでEmotionサービスにStreamではなくURLを渡す

### DIFF
--- a/hands-on/readme.md
+++ b/hands-on/readme.md
@@ -660,10 +660,9 @@ public class EmotionService
     private static async Task<Emotion[]> GetHappinessAsync(string url)
     {
         var client = new HttpClient();
-        var stream = await client.GetStreamAsync(url);
         var emotionClient = new EmotionServiceClient("INSERT_EMOTION_SERVICE_KEY_HERE");
 
-        var emotionResults = await emotionClient.RecognizeAsync(stream);
+        var emotionResults = await emotionClient.RecognizeAsync(url);
 
         if (emotionResults == null || emotionResults.Count() == 0)
         {


### PR DESCRIPTION
UWPをローカルPCで実行した場合に
画像URLから取得したStreamをEmotionサービスに渡す方式だと
「Image size is too small or too big.」エラーが返される。
EmotionサービスにURLを渡せば問題なく動作する。